### PR TITLE
heroku 배포 - DB변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
cleardb 의 기본 mysql 버전이 `5.6`으로 너무 낮기 때문에 발생한 것으로 확인 ( `article_comment_content` 인덱스 사이즈 초과 )
대안으로 jawsdb 를 찾음. 기본 mysql 버전이 `8.0` 이를 이용해 환경변수를 다시 작업

This fixes #56

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup